### PR TITLE
feat: 重新開啟訂單按鈕、關閉訂單確認對話框、手機 Navbar RWD 修正

### DIFF
--- a/components/layout/header-bar.tsx
+++ b/components/layout/header-bar.tsx
@@ -5,11 +5,16 @@ import { Button } from "@/components/ui/button"
 import { ConfirmDialog } from "@/components/shared/confirm-dialog"
 import { useAuth } from "@/contexts/auth-context"
 import { useAdmin } from "@/hooks/use-admin"
-import { useOrder, useCloseOrder, useDeleteOrder } from "@/hooks/use-orders"
-import { CircleDot } from "lucide-react"
+import {
+  useOrder,
+  useCloseOrder,
+  useDeleteOrder,
+  useReopenOrder,
+} from "@/hooks/use-orders"
+import { CircleDot, Menu, X } from "lucide-react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import { AddOrderItemDialog } from "@/components/orders/add-order-item-dialog"
 import { CreateOrderDialog } from "@/components/orders/create-order-dialog"
@@ -21,6 +26,7 @@ export default function HeaderBar() {
   const { isAdmin, isLoading: adminLoading } = useAdmin()
   const router = useRouter()
   const pathname = usePathname()
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
 
   const orderId = useMemo(() => {
     if (pathname?.startsWith("/orders/")) {
@@ -29,11 +35,16 @@ export default function HeaderBar() {
     return null
   }, [pathname])
 
+  useEffect(() => {
+    setMobileMenuOpen(false)
+  }, [pathname])
+
   const { data: orderData } = useOrder(orderId ?? undefined)
   const orderStatus = orderData?.status ?? null
 
   const closeOrder = useCloseOrder()
   const deleteOrder = useDeleteOrder()
+  const reopenOrder = useReopenOrder()
 
   const handleAvatarClick = () => {
     router.push("/me")
@@ -44,8 +55,7 @@ export default function HeaderBar() {
     try {
       await closeOrder.mutateAsync(orderId)
       toast.success("訂單已關閉")
-    } catch (error) {
-      console.error("Error closing order:", error)
+    } catch {
       toast.error("關閉訂單失敗")
     }
   }
@@ -57,155 +67,244 @@ export default function HeaderBar() {
       toast.success("訂單已刪除")
       router.push("/")
     } catch (error) {
-      console.error("Error deleting order:", error)
       toast.error(error instanceof Error ? error.message : "刪除訂單失敗")
     }
   }
 
-  return (
-    <header className="mx-auto flex w-full max-w-5xl items-center justify-between p-4 px-6">
-      <nav className="flex items-center gap-4">
-        <Link href="/" className="text-lg font-semibold">
-          訂單
-        </Link>
-        <Link href="/menus" className="text-lg font-semibold">
-          店家
-        </Link>
-        <Link href="/rank" className="text-lg font-semibold">
-          排名
-        </Link>
-        <Link href="/stats" className="text-lg font-semibold">
-          統計
-        </Link>
-      </nav>
+  const handleReopenOrder = async () => {
+    if (!orderId) return
+    try {
+      await reopenOrder.mutateAsync(orderId)
+      toast.success("訂單已重新開啟")
+    } catch {
+      toast.error("重新開啟訂單失敗")
+    }
+  }
 
-      <div className="flex items-center gap-3">
-        {!adminLoading && isAdmin && user && (
+  const adminOrderActions =
+    !adminLoading && isAdmin && user && orderId ? (
+      <>
+        {orderStatus === "active" && (
           <>
-            {pathname === "/" && (
-              <CreateOrderDialog
-                trigger={
-                  <Button
-                    size="sm"
-                    className="animate-in duration-200 fade-in slide-in-from-right-2"
-                  >
-                    新增訂單
-                  </Button>
-                }
-                onSuccess={() => {
-                  toast.success("訂單已建立")
-                }}
-              />
-            )}
-
-            {pathname === "/menus" && (
-              <CreateRestaurantDialog
-                trigger={
-                  <Button
-                    size="sm"
-                    className="animate-in duration-200 fade-in slide-in-from-right-2"
-                  >
-                    新增店家
-                  </Button>
-                }
-                onSuccess={() => {
-                  toast.success("店家已建立")
-                }}
-              />
-            )}
-
-            {orderId && orderStatus === "active" && (
-              <>
-                <ConfirmDialog
-                  trigger={
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      className="animate-in duration-200 fade-in slide-in-from-right-2"
-                    >
-                      刪除訂單
-                    </Button>
-                  }
-                  title="確定要刪除訂單嗎？"
-                  description="此操作將永久刪除訂單，且無法復原。"
-                  confirmText="刪除"
-                  variant="destructive"
-                  onConfirm={handleDeleteOrder}
-                />
-                <Button
-                  onClick={handleCloseOrder}
-                  variant="default"
-                  size="sm"
-                  className="animate-in duration-200 fade-in slide-in-from-right-2"
-                >
+            <ConfirmDialog
+              trigger={
+                <Button variant="destructive" size="sm">
+                  刪除訂單
+                </Button>
+              }
+              title="確定要刪除訂單嗎？"
+              description="此操作將永久刪除訂單，且無法復原。"
+              confirmText="刪除"
+              variant="destructive"
+              onConfirm={handleDeleteOrder}
+            />
+            <ConfirmDialog
+              trigger={
+                <Button variant="outline" size="sm">
                   關閉訂單
                 </Button>
-              </>
-            )}
+              }
+              title="確定要關閉訂單嗎？"
+              description="關閉後訂單將停止接受新增，可透過重新開啟恢復。"
+              confirmText="關閉"
+              onConfirm={handleCloseOrder}
+            />
           </>
         )}
-
-        <ThemeToggle />
-
-        <Button size="icon" variant="ghost" asChild>
-          <Link
-            href="https://github.com/NYCU-WinLab/bento.winlab.tw/issues/new/choose"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="回報問題"
-          >
-            <CircleDot className="size-4" />
-          </Link>
-        </Button>
-
-        {orderId && orderStatus === "active" && (
-          <AddOrderItemDialog
-            orderId={orderId}
+        {orderStatus === "closed" && (
+          <ConfirmDialog
             trigger={
-              <Button
-                size="sm"
-                className="animate-in duration-200 fade-in slide-in-from-right-2"
-              >
-                新增訂餐
+              <Button variant="default" size="sm">
+                重新開啟訂單
               </Button>
             }
-            onSuccess={() => {
-              toast.success("已新增訂餐")
-            }}
+            title="確定要重新開啟訂單嗎？"
+            description="重新開啟後，訂單將可以繼續接受訂餐。"
+            confirmText="開啟"
+            onConfirm={handleReopenOrder}
           />
         )}
+      </>
+    ) : null
 
-        {loading ? (
-          <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
-        ) : user ? (
-          <button
-            onClick={handleAvatarClick}
-            className="cursor-pointer transition-opacity hover:opacity-80"
-          >
-            <Avatar>
-              <AvatarImage
-                src={user.user_metadata?.avatar_url}
-                alt={user.email}
-              />
-              <AvatarFallback>
-                {user.email?.charAt(0).toUpperCase() || "U"}
-              </AvatarFallback>
-            </Avatar>
-          </button>
-        ) : (
-          <Button size="sm" asChild className="animate-in duration-200 fade-in">
+  const adminPageActions =
+    !adminLoading && isAdmin && user ? (
+      <>
+        {pathname === "/" && (
+          <CreateOrderDialog
+            trigger={<Button size="sm">新增訂單</Button>}
+            onSuccess={() => toast.success("訂單已建立")}
+          />
+        )}
+        {pathname === "/menus" && (
+          <CreateRestaurantDialog
+            trigger={<Button size="sm">新增店家</Button>}
+            onSuccess={() => toast.success("店家已建立")}
+          />
+        )}
+      </>
+    ) : null
+
+  const navLinks = (
+    <>
+      <Link href="/" className="text-lg font-semibold">
+        訂單
+      </Link>
+      <Link href="/menus" className="text-lg font-semibold">
+        店家
+      </Link>
+      <Link href="/rank" className="text-lg font-semibold">
+        排名
+      </Link>
+      <Link href="/stats" className="text-lg font-semibold">
+        統計
+      </Link>
+    </>
+  )
+
+  return (
+    <>
+      <header className="mx-auto flex w-full max-w-5xl items-center justify-between p-4 px-6">
+        <div className="flex items-center gap-4">
+          {/* Desktop nav */}
+          <nav className="hidden items-center gap-4 md:flex">{navLinks}</nav>
+
+          {/* Mobile brand */}
+          <Link href="/" className="text-lg font-semibold md:hidden">
+            訂餐
+          </Link>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {/* Desktop admin actions */}
+          <div className="hidden items-center gap-3 md:flex">
+            {adminPageActions}
+            {adminOrderActions}
+          </div>
+
+          <ThemeToggle />
+
+          <Button size="icon" variant="ghost" asChild className="hidden md:flex">
             <Link
-              href={
-                pathname && pathname !== "/login"
-                  ? `/login?next=${encodeURIComponent(pathname)}`
-                  : "/login"
-              }
+              href="https://github.com/NYCU-WinLab/bento.winlab.tw/issues/new/choose"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="回報問題"
             >
-              登入
+              <CircleDot className="size-4" />
             </Link>
           </Button>
-        )}
-      </div>
-    </header>
+
+          {orderId && orderStatus === "active" && (
+            <AddOrderItemDialog
+              orderId={orderId}
+              trigger={<Button size="sm">新增訂餐</Button>}
+              onSuccess={() => toast.success("已新增訂餐")}
+            />
+          )}
+
+          {loading ? (
+            <div className="h-8 w-8 animate-pulse rounded-full bg-muted" />
+          ) : user ? (
+            <button
+              onClick={handleAvatarClick}
+              className="cursor-pointer transition-opacity hover:opacity-80"
+            >
+              <Avatar>
+                <AvatarImage
+                  src={user.user_metadata?.avatar_url}
+                  alt={user.email}
+                />
+                <AvatarFallback>
+                  {user.email?.charAt(0).toUpperCase() || "U"}
+                </AvatarFallback>
+              </Avatar>
+            </button>
+          ) : (
+            <Button size="sm" asChild>
+              <Link
+                href={
+                  pathname && pathname !== "/login"
+                    ? `/login?next=${encodeURIComponent(pathname)}`
+                    : "/login"
+                }
+              >
+                登入
+              </Link>
+            </Button>
+          )}
+
+          {/* Mobile hamburger */}
+          <Button
+            size="icon"
+            variant="ghost"
+            className="md:hidden"
+            onClick={() => setMobileMenuOpen((prev) => !prev)}
+            aria-label={mobileMenuOpen ? "關閉選單" : "開啟選單"}
+          >
+            {mobileMenuOpen ? (
+              <X className="size-5" />
+            ) : (
+              <Menu className="size-5" />
+            )}
+          </Button>
+        </div>
+      </header>
+
+      {/* Mobile dropdown menu */}
+      {mobileMenuOpen && (
+        <div className="fixed inset-x-0 top-16 z-40 border-b bg-background/95 shadow-md backdrop-blur-sm md:hidden">
+          <nav className="mx-auto flex max-w-5xl flex-col gap-1 px-6 py-4">
+            <Link
+              href="/"
+              className="rounded-md px-3 py-2 text-lg font-semibold hover:bg-accent"
+            >
+              訂單
+            </Link>
+            <Link
+              href="/menus"
+              className="rounded-md px-3 py-2 text-lg font-semibold hover:bg-accent"
+            >
+              店家
+            </Link>
+            <Link
+              href="/rank"
+              className="rounded-md px-3 py-2 text-lg font-semibold hover:bg-accent"
+            >
+              排名
+            </Link>
+            <Link
+              href="/stats"
+              className="rounded-md px-3 py-2 text-lg font-semibold hover:bg-accent"
+            >
+              統計
+            </Link>
+
+            {(!adminLoading && isAdmin && user) || orderId ? (
+              <div className="mt-2 flex flex-col gap-2 border-t pt-3">
+                {adminPageActions && (
+                  <div className="flex flex-wrap gap-2">{adminPageActions}</div>
+                )}
+                {adminOrderActions && (
+                  <div className="flex flex-wrap gap-2">
+                    {adminOrderActions}
+                  </div>
+                )}
+                <Button size="sm" variant="ghost" asChild className="w-fit">
+                  <Link
+                    href="https://github.com/NYCU-WinLab/bento.winlab.tw/issues/new/choose"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <CircleDot className="mr-1.5 size-4" />
+                    回報問題
+                  </Link>
+                </Button>
+              </div>
+            ) : null}
+          </nav>
+        </div>
+      )}
+    </>
   )
 }

--- a/hooks/use-orders.ts
+++ b/hooks/use-orders.ts
@@ -216,3 +216,24 @@ export function useDeleteOrder() {
     },
   })
 }
+
+export function useReopenOrder() {
+  const supabase = createClient()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async (orderId: string) => {
+      const { data, error } = await supabase
+        .from("bento_orders")
+        .update({ status: "active", closed_at: null })
+        .eq("id", orderId)
+        .select()
+        .single()
+      if (error) throw error
+      return data
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.orders.all })
+    },
+  })
+}


### PR DESCRIPTION
## Summary

- 新增「重新開啟訂單」按鈕：管理員在已關閉訂單頁面可一鍵重開（附確認對話框），解決誤關後無法恢復的問題
- 「關閉訂單」改為 ConfirmDialog：防止手機誤觸直接關閉訂單
- 手機 Navbar RWD 修正：導航連結與管理員操作改為 hamburger 收折選單，桌面版 (`md+`) 保留原排版

## 改動檔案

- `hooks/use-orders.ts` — 新增 `useReopenOrder` mutation（更新 status → active、清除 closed_at）
- `components/layout/header-bar.tsx` — hamburger 選單、重開訂單按鈕、關閉訂單改 ConfirmDialog

## Test Plan

- [ ] 在訂單頁面確認「關閉訂單」按鈕現在會跳出確認對話框
- [ ] 關閉訂單後確認出現「重新開啟訂單」按鈕
- [ ] 點「重新開啟訂單」後訂單狀態回到 active，可以繼續新增訂餐
- [ ] 手機寬度（375px）確認 Navbar 不溢出，hamburger 可展開/收折
- [ ] 桌面寬度（1024px+）確認原有排版不受影響

Closes #19